### PR TITLE
Adhoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 group :development do
   gem 'rake'
+  gem 'pry'
+  gem 'pry-byebug'
 end
 
 gemspec

--- a/assets/canals.sh
+++ b/assets/canals.sh
@@ -18,9 +18,14 @@ _canal_complete() {
   # Setup the second level
   if [ $COMP_CWORD -eq 2 ]; then
     case "$prev" in
-      start|stop|restart|update)
+      start|update)
         COMPREPLY=( $(compgen \
                       -W "`canal list tunnels`" \
+                      -- $cur) )
+        ;;
+      stop|restart)
+        COMPREPLY=( $(compgen \
+                      -W "`canal list session`" \
                       -- $cur) )
         ;;
       environment)

--- a/assets/canals.sh
+++ b/assets/canals.sh
@@ -10,7 +10,7 @@ _canal_complete() {
   # Setup the base level (everything after "canal")
   if [ $COMP_CWORD -eq 1 ]; then
     COMPREPLY=( $(compgen \
-                  -W "create environment help repo restart session setup start stop update" \
+                  -W "adhoc create environment help repo restart session setup start stop update" \
                   -- $cur) )
     return 0
   fi

--- a/lib/canals/cli.rb
+++ b/lib/canals/cli.rb
@@ -124,7 +124,7 @@ module Canals
       method_option :bind_address, :type => :string, :desc => "The bind address to connect to"
       def adhoc(remote_host, remote_port, local_port=nil)
         opts = {"adhoc" => true, "remote_host" => remote_host, "remote_port" => remote_port, "local_port" => local_port}.merge(options)
-        opts["name"] ||= "adhoc_#{remote_host}_#{remote_port}"
+        opts["name"] ||= "adhoc-#{remote_host}-#{remote_port}"
         opts = Canals::CanalOptions.new(opts)
         tstart(opts)
       end

--- a/lib/canals/cli.rb
+++ b/lib/canals/cli.rb
@@ -104,6 +104,19 @@ module Canals
         say "* use --full to show more data", [:white, :dim] if !options[:full]
       end
 
+      desc "adhoc REMOTE_HOST REMOTE_PORT [LOCAL_PORT]", "Create and run a new tunnel, without keeping it in the repository; if LOCAL_PORT isn't supplied, REMOTE_PORT will be used as LOCAL"
+      method_option :name,         :type => :string, :desc => "The name to use for the tunnel, if not supplied a template will be generated"
+      method_option :env,          :type => :string, :desc => "The proxy environment to use"
+      method_option :hostname,     :type => :string, :desc => "The proxy host we will use to connect through"
+      method_option :user,         :type => :string, :desc => "The user for the ssh proxy host"
+      method_option :bind_address, :type => :string, :desc => "The bind address to connect to"
+      def adhoc(remote_host, remote_port, local_port=nil)
+        opts = {"adhoc" => true, "remote_host" => remote_host, "remote_port" => remote_port, "local_port" => local_port}.merge(options)
+        opts["name"] ||= "adhoc_#{remote_host}_#{remote_port}"
+        opts = Canals::CanalOptions.new(opts)
+        tstart(opts)
+      end
+
       desc "environment SUBCOMMAND", "Environment related command (use 'canal environment help' to find out more)"
       subcommand "environment", Canals::Cli::Environment
 

--- a/lib/canals/cli.rb
+++ b/lib/canals/cli.rb
@@ -38,6 +38,18 @@ module Canals
         say "Tunnel #{name.inspect} created.", :green
       end
 
+      desc 'delete NAME', "Delete an existing tunnel; if tunnel is active, stop it first"
+      def delete(name)
+        tunnel = Canals.repository.get(name)
+        if tunnel.nil?
+          say "couldn't find tunnel #{name.inspect}. try using 'create' instead", :red
+          return
+        end
+        tstop(name, silent: true)
+        Canals.repository.delete(name)
+        say "Tunnel #{name.inspect} deleted.", :green
+      end
+
       desc 'update NAME', "Update an existing tunnel"
       method_option :remote_host,  :type => :string, :desc => "The remote host of the tunnel"
       method_option :remote_port,  :type => :string, :desc => "The remote port of the tunnel"

--- a/lib/canals/cli.rb
+++ b/lib/canals/cli.rb
@@ -75,8 +75,15 @@ module Canals
       end
 
       desc 'start NAME', 'Start tunnel'
+      method_option :local_port,   :type => :numeric, :desc => "The local port to use"
       def start(name)
-        tstart(name)
+        tunnel = tunnel_options(name)
+        if options["local_port"]
+          tunnel.local_port = options["local_port"]
+          tunnel.name = "adhoc-#{name}-#{options["local_port"]}"
+          tunnel.adhoc = true
+        end
+        tstart(tunnel)
       end
 
       desc 'stop NAME', 'Stop tunnel'

--- a/lib/canals/cli/helpers.rb
+++ b/lib/canals/cli/helpers.rb
@@ -11,15 +11,19 @@ module Canals
         say "Tunnel #{name.inspect} stopped."
       end
 
-      def tstart(name)
-        pid = Canals.start(name)
-        tunnel = Canals.repository.get(name)
-        say "Created tunnel #{name.inspect} with pid #{pid}. You can access it using '#{tunnel.bind_address}:#{tunnel.local_port}'"
+      def tstart(tunnel_opts)
+        if tunnel_opts.instance_of? String
+          tunnel_opts = Canals.repository.get(tunnel_opts)
+        end
+        pid = Canals.start(tunnel_opts)
+        say "Created tunnel #{tunnel_opts.name.inspect} with pid #{pid}. You can access it using '#{tunnel_opts.bind_address}:#{tunnel_opts.local_port}'"
         pid
       rescue Canals::Exception => e
-        tunnel = Canals.repository.get(name)
-        isalive = Canals.isalive? tunnel
-        say "Unable to create tunnel #{name.inspect}#{isalive ? ', A tunnel for ' + name.inspect + ' Already exists.' : ''}", :red
+        if tunnel_opts.instance_of? String
+          tunnel_opts = Canals.repository.get(tunnel_opts)
+        end
+        isalive = Canals.isalive? tunnel_opts
+        say "Unable to create tunnel #{tunnel_opts.name.inspect}#{isalive ? ', A tunnel for ' + tunnel_opts.name.inspect + ' Already exists.' : ''}", :red
         0
       end
 

--- a/lib/canals/cli/helpers.rb
+++ b/lib/canals/cli/helpers.rb
@@ -6,20 +6,20 @@ module Canals
   module Cli
     module Helpers
 
-      def tstop(tunnel_opts)
+      def tstop(tunnel_opts, silent: false)
         if tunnel_opts.instance_of? String
           tunnel_opts = tunnel_options(tunnel_opts)
         end
         Canals.stop(tunnel_opts)
-        say "Tunnel #{tunnel_opts.name.inspect} stopped."
+        say "Tunnel #{tunnel_opts.name.inspect} stopped." unless silent
       end
 
-      def tstart(tunnel_opts)
+      def tstart(tunnel_opts, silent: false)
         if tunnel_opts.instance_of? String
           tunnel_opts = tunnel_options(tunnel_opts)
         end
         pid = Canals.start(tunnel_opts)
-        say "Created tunnel #{tunnel_opts.name.inspect} with pid #{pid}. You can access it using '#{tunnel_opts.bind_address}:#{tunnel_opts.local_port}'"
+        say "Created tunnel #{tunnel_opts.name.inspect} with pid #{pid}. You can access it using '#{tunnel_opts.bind_address}:#{tunnel_opts.local_port}'" unless silent
         pid
       rescue Canals::Exception => e
         if tunnel_opts.instance_of? String

--- a/lib/canals/cli/helpers.rb
+++ b/lib/canals/cli/helpers.rb
@@ -6,30 +6,44 @@ module Canals
   module Cli
     module Helpers
 
-      def tstop(name)
-        Canals.stop(name)
-        say "Tunnel #{name.inspect} stopped."
+      def tstop(tunnel_opts)
+        if tunnel_opts.instance_of? String
+          tunnel_opts = tunnel_options(tunnel_opts)
+        end
+        Canals.stop(tunnel_opts)
+        say "Tunnel #{tunnel_opts.name.inspect} stopped."
       end
 
       def tstart(tunnel_opts)
         if tunnel_opts.instance_of? String
-          tunnel_opts = Canals.repository.get(tunnel_opts)
+          tunnel_opts = tunnel_options(tunnel_opts)
         end
         pid = Canals.start(tunnel_opts)
         say "Created tunnel #{tunnel_opts.name.inspect} with pid #{pid}. You can access it using '#{tunnel_opts.bind_address}:#{tunnel_opts.local_port}'"
         pid
       rescue Canals::Exception => e
         if tunnel_opts.instance_of? String
-          tunnel_opts = Canals.repository.get(tunnel_opts)
+          tunnel_opts = tunnel_options(tunnel_opts)
         end
         isalive = Canals.isalive? tunnel_opts
         say "Unable to create tunnel #{tunnel_opts.name.inspect}#{isalive ? ', A tunnel for ' + tunnel_opts.name.inspect + ' Already exists.' : ''}", :red
         0
       end
 
-      def trestart(name)
-        tstop(name)
-        tstart(name)
+      def trestart(tunnel_opts)
+        if tunnel_opts.instance_of? String
+          tunnel_opts = tunnel_options(tunnel_opts)
+        end
+        tstop(tunnel_opts)
+        tstart(tunnel_opts)
+      end
+
+      def tunnel_options(name)
+        if (Canals.repository.has?(name))
+          Canals.repository.get(name)
+        else
+          Canals.session.get_obj(name)
+        end
       end
 
       def startup_checks

--- a/lib/canals/cli/helpers.rb
+++ b/lib/canals/cli/helpers.rb
@@ -39,10 +39,10 @@ module Canals
       end
 
       def tunnel_options(name)
-        if (Canals.repository.has?(name))
-          Canals.repository.get(name)
-        elsif (Canals.session.has?(name))
+        if (Canals.session.has?(name))
           Canals.session.get_obj(name)
+        elsif (Canals.repository.has?(name))
+          Canals.repository.get(name)
         else
           raise Thor::Error.new "Unable to find tunnel #{name.inspect}."
         end

--- a/lib/canals/cli/helpers.rb
+++ b/lib/canals/cli/helpers.rb
@@ -41,8 +41,10 @@ module Canals
       def tunnel_options(name)
         if (Canals.repository.has?(name))
           Canals.repository.get(name)
-        else
+        elsif (Canals.session.has?(name))
           Canals.session.get_obj(name)
+        else
+          raise Thor::Error.new "Unable to find tunnel #{name.inspect}."
         end
       end
 

--- a/lib/canals/cli/list.rb
+++ b/lib/canals/cli/list.rb
@@ -20,6 +20,12 @@ module Canals
         say tunnels.sort.join " "
       end
 
+      desc 'session', 'List the tunnels in the current session'
+      def session
+        tunnels = Canals.session.map{ |conf| conf[:name] }
+        say tunnels.sort.join " "
+      end
+
       desc 'commands', 'List all the base level commands'
       def commands(subcommand=nil)
         thor_class = Canals::Cli::Application

--- a/lib/canals/cli/session.rb
+++ b/lib/canals/cli/session.rb
@@ -87,8 +87,12 @@ module Canals
           c = session_color(session)
           val = case key
                 when "local_port"
-                  entry = Canals.repository.get(session[:name])
-                  entry.local_port if entry
+                  if session[key.to_sym]
+                    session[key.to_sym]
+                  else
+                    entry = Canals.repository.get(session[:name])
+                    entry.local_port if entry
+                  end
                 when "up"
                   checkmark(session_alive(session))
                 else

--- a/lib/canals/cli/session.rb
+++ b/lib/canals/cli/session.rb
@@ -25,36 +25,36 @@ module Canals
 
       desc "restore", "Restore the connection to tunnels which aren't working"
       def restore
-        on_all_canals_in_session(:restore) do |name|
-          if Canals.isalive? name
-            say "Canal #{name.inspect} is running."
+        on_all_canals_in_session(:restore) do |canal|
+          if Canals.isalive? canal
+            say "Canal #{canal.name.inspect} is running."
           else
-            Canals.session.del(name)
-            tstart(name)
+            Canals.session.del(canal.name)
+            tstart(canal)
           end
         end
       end
 
       desc "restart", "Restart the current session (closing and starting all connections)"
       def restart
-        on_all_canals_in_session(:restart) do |name|
-          trestart(name)
+        on_all_canals_in_session(:restart) do |canal|
+          trestart(canal)
         end
       end
 
       desc "stop", "Stop the current session"
       def stop
-        on_all_canals_in_session(:stop) do |name|
-          tstop(name)
+        on_all_canals_in_session(:stop) do |canal|
+          tstop(canal)
         end
       end
 
       no_commands do
         def on_all_canals_in_session(command, &block)
           return if session_empty?
-          Canals.session.map{|s| s[:name]}.each do |name|
-            say "#{command.to_s.capitalize} canal #{name.inspect}:", :green
-            block.call(name)
+          Canals.session.each_obj do |canal|
+            say "#{command.to_s.capitalize} canal #{canal.name.inspect}:", :green
+            block.call(canal)
           end
           say
           say "#{command} done.", :green

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -17,7 +17,12 @@ module Canals
       exit_code = tunnel_start(tunnel_opts)
       raise Canals::Exception, "could not start tunnel" unless exit_code.success?
       pid = tunnel_pid(tunnel_opts)
-      Canals.session.add({name: tunnel_opts.name, pid: pid, socket: socket_file(tunnel_opts)})
+      session_data = {name: tunnel_opts.name, pid: pid, socket: socket_file(tunnel_opts)}
+      if tunnel_opts.adhoc
+        session_data[:adhoc] = true
+        session_data[:local_port] = tunnel_opts.local_port
+      end
+      Canals.session.add(session_data)
       pid.to_i
     end
 

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -18,10 +18,7 @@ module Canals
       raise Canals::Exception, "could not start tunnel" unless exit_code.success?
       pid = tunnel_pid(tunnel_opts)
       session_data = {name: tunnel_opts.name, pid: pid, socket: socket_file(tunnel_opts)}
-      if tunnel_opts.adhoc
-        session_data[:adhoc] = true
-        session_data[:local_port] = tunnel_opts.local_port
-      end
+      session_data.merge!(tunnel_opts.to_hash(:full)) if tunnel_opts.adhoc
       Canals.session.add(session_data)
       pid.to_i
     end

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -18,7 +18,7 @@ module Canals
       raise Canals::Exception, "could not start tunnel" unless exit_code.success?
       pid = tunnel_pid(tunnel_opts)
       session_data = {name: tunnel_opts.name, pid: pid, socket: socket_file(tunnel_opts)}
-      session_data.merge!(tunnel_opts.to_hash(:full)) if tunnel_opts.adhoc
+      session_data = tunnel_opts.to_hash(:full).merge(session_data) if tunnel_opts.adhoc
       Canals.session.add(session_data)
       pid.to_i
     end
@@ -42,7 +42,11 @@ module Canals
 
     def isalive?(tunnel_opts)
       if tunnel_opts.instance_of? String
-        tunnel_opts = Canals.repository.get(tunnel_opts)
+        if (Canals.repository.has?(tunnel_opts))
+          tunnel_opts = Canals.repository.get(tunnel_opts)
+        else
+          tunnel_opts = Canals.session.get_obj(tunnel_opts)
+        end
       end
       !!tunnel_pid(tunnel_opts)
     end

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -25,7 +25,11 @@ module Canals
 
     def stop(tunnel_opts)
       if tunnel_opts.instance_of? String
-        tunnel_opts = Canals.repository.get(tunnel_opts)
+        if (Canals.repository.has?(tunnel_opts))
+          tunnel_opts = Canals.repository.get(tunnel_opts)
+        else
+          tunnel_opts = Canals.session.get_obj(tunnel_opts)
+        end
       end
       tunnel_close(tunnel_opts)
       Canals.session.del(tunnel_opts.name)

--- a/lib/canals/environment.rb
+++ b/lib/canals/environment.rb
@@ -7,24 +7,24 @@ module Canals
     attr_reader :name, :user, :hostname, :pem
     def initialize(args)
       @args = validate?(args)
-      @name = @args["name"]
-      @user = @args["user"]
-      @hostname = @args["hostname"]
-      @pem = @args["pem"]
+      @name = @args[:name]
+      @user = @args[:user]
+      @hostname = @args[:hostname]
+      @pem = @args[:pem]
     end
 
     def validate?(args)
-      vargs = args.dup
-      raise CanalEnvironmentError.new("Missing option: \"name\" in environment creation") if args["name"].nil?
+      vargs = args.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+      raise CanalEnvironmentError.new("Missing option: \"name\" in environment creation") if vargs[:name].nil?
       vargs
     end
 
     def default=(val)
-      @args["default"] = !!val
+      @args[:default] = !!val
     end
 
     def is_default?
-      !!@args["default"]
+      !!@args[:default]
     end
 
     def to_yaml
@@ -32,7 +32,7 @@ module Canals
     end
 
     def to_hash
-      @args.dup
+      Marshal.load(Marshal.dump(@args))
     end
 
   end

--- a/lib/canals/options.rb
+++ b/lib/canals/options.rb
@@ -1,20 +1,20 @@
 require 'psych'
 
 module Canals
-  class CanalOptionError < StandardError; end
+  CanalOptionError = Class.new StandardError
 
   class CanalOptions
     BIND_ADDRESS = "127.0.0.1"
-    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env, :adhoc
+    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env
 
     def initialize(args)
       @args = validate?(args)
-      @name = @args["name"]
-      @remote_host = @args["remote_host"]
-      @remote_port = @args["remote_port"]
-      @local_port = @args["local_port"]
-      @adhoc = @args["adhoc"] || false
-      @env_name = @args['env']
+      @name = @args[:name]
+      @remote_host = @args[:remote_host]
+      @remote_port = @args[:remote_port]
+      @local_port = @args[:local_port]
+      @adhoc = @args[:adhoc]
+      @env_name = @args[:env]
       @env = Canals.repository.environment(@env_name)
     end
 
@@ -23,21 +23,25 @@ module Canals
     end
 
     def bind_address
-      return @args["bind_address"] if @args["bind_address"]
+      return @args[:bind_address] if @args[:bind_address]
       return Canals.config[:bind_address] if Canals.config[:bind_address]
       return BIND_ADDRESS
     end
 
     def hostname
-      get_env_var("hostname")
+      get_env_var(:hostname)
     end
 
     def user
-      get_env_var("user")
+      get_env_var(:user)
     end
 
     def pem
-      get_env_var("pem")
+      get_env_var(:pem)
+    end
+
+    def adhoc
+      @adhoc || false
     end
 
     def proxy
@@ -51,22 +55,28 @@ module Canals
       Psych.dump(@args)
     end
 
-    def to_hash
-      @args.dup
+    def to_hash(mode=:basic)
+      args_copy = Marshal.load(Marshal.dump(@args))
+      args_copy.merge! exploded_options if mode == :full
+      args_copy
+    end
+
+    def exploded_options
+      {bind_address: bind_address, hostname: hostname, user: user, pem: pem, proxy: proxy, adhoc: adhoc}
     end
 
     private
 
     def validate?(args)
-      vargs = args.dup
-      raise CanalOptionError.new("Missing option: \"name\" in canal creation") if args["name"].nil?
-      raise CanalOptionError.new("Missing option: \"remote_host\" in canal creation") if args["remote_host"].nil?
-      raise CanalOptionError.new("Missing option: \"remote_port\" in canal creation") if args["remote_port"].nil?
-      vargs["remote_port"] = vargs["remote_port"].to_i
-      if vargs["local_port"].nil?
-        vargs["local_port"] = vargs["remote_port"]
+      vargs = args.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
+      raise CanalOptionError.new("Missing option: \"name\" in canal creation") if vargs[:name].nil?
+      raise CanalOptionError.new("Missing option: \"remote_host\" in canal creation") if vargs[:remote_host].nil?
+      raise CanalOptionError.new("Missing option: \"remote_port\" in canal creation") if vargs[:remote_port].nil?
+      vargs[:remote_port] = vargs[:remote_port].to_i
+      if vargs[:local_port].nil?
+        vargs[:local_port] = vargs[:remote_port]
       else
-        vargs["local_port"] = vargs["local_port"].to_i
+        vargs[:local_port] = vargs[:local_port].to_i
       end
       vargs
     end

--- a/lib/canals/options.rb
+++ b/lib/canals/options.rb
@@ -5,7 +5,7 @@ module Canals
 
   class CanalOptions
     BIND_ADDRESS = "127.0.0.1"
-    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env
+    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env, :adhoc
 
     def initialize(args)
       @args = validate?(args)
@@ -13,6 +13,7 @@ module Canals
       @remote_host = @args["remote_host"]
       @remote_port = @args["remote_port"]
       @local_port = @args["local_port"]
+      @adhoc = @args["adhoc"] || false
       @env_name = @args['env']
       @env = Canals.repository.environment(@env_name)
     end

--- a/lib/canals/options.rb
+++ b/lib/canals/options.rb
@@ -5,15 +5,24 @@ module Canals
 
   class CanalOptions
     BIND_ADDRESS = "127.0.0.1"
-    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env
+    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env, :adhoc
+
+    # define setters
+    [:name, :local_port, :adhoc].each do |attribute|
+      define_method :"#{attribute}=" do |value|
+        @args[attribute] = value
+        self.instance_variable_set(:"@#{attribute}", value)
+      end
+    end
 
     def initialize(args)
-      @args = validate?(args)
+      @original_args = validate?(args)
+      @args = Marshal.load(Marshal.dump(@original_args))
       @name = @args[:name]
       @remote_host = @args[:remote_host]
       @remote_port = @args[:remote_port]
       @local_port = @args[:local_port]
-      @adhoc = @args[:adhoc]
+      @adhoc = @args[:adhoc] || false
       @env_name = @args[:env]
       @env = Canals.repository.environment(@env_name)
     end
@@ -38,10 +47,6 @@ module Canals
 
     def pem
       get_env_var(:pem)
-    end
-
-    def adhoc
-      @adhoc || false
     end
 
     def proxy

--- a/lib/canals/repository.rb
+++ b/lib/canals/repository.rb
@@ -34,6 +34,11 @@ module Canals
       save! if save
     end
 
+    def delete(name, save=true)
+      @repo[TUNNELS].delete(name)
+      save! if save
+    end
+
     def get(name)
       return nil if !@repo[:tunnels].has_key? name
       CanalOptions.new(@repo[:tunnels][name])

--- a/lib/canals/repository.rb
+++ b/lib/canals/repository.rb
@@ -39,6 +39,10 @@ module Canals
       CanalOptions.new(@repo[:tunnels][name])
     end
 
+    def has?(name)
+      return @repo[:tunnels].has_key? name
+    end
+
     def add_environment(environment, save=true)
       if environment.is_default?
         @repo[ENVIRONMENTS].each { |name, env| env.delete("default") }

--- a/lib/canals/repository.rb
+++ b/lib/canals/repository.rb
@@ -29,7 +29,7 @@ module Canals
     def add(options, save=true)
       @repo[TUNNELS][options.name] = options.to_hash
       if options.env_name.nil? && !options.env.nil? && options.env.is_default?
-        @repo[TUNNELS][options.name]["env"] = options.env.name
+        @repo[TUNNELS][options.name][:env] = options.env.name
       end
       save! if save
     end

--- a/lib/canals/session.rb
+++ b/lib/canals/session.rb
@@ -40,6 +40,14 @@ module Canals
       end
     end
 
+    def get_obj(session_id)
+      CanalOptions.new(get(session_id))
+    end
+
+    def has?(session_id)
+      get(session_id) != nil
+    end
+
     def alive?(session_id)
       sess = get(session_id)
       File.exist?(sess[:socket])

--- a/lib/canals/version.rb
+++ b/lib/canals/version.rb
@@ -1,6 +1,6 @@
 module Canals
 
   # Canals gem current version
-  VERSION = "0.8.7"
+  VERSION = "0.9.0"
 
 end

--- a/spec/canals/environment_spec.rb
+++ b/spec/canals/environment_spec.rb
@@ -67,10 +67,18 @@ describe Canals::Environment do
       args = {"name" => name, "default" => true}
       env = Canals::Environment.new(args)
       expect(env.is_default?).to eq true
-      expect(env.to_hash["default"]).to eq true
+      expect(env.to_hash[:default]).to eq true
       env.default = false
       expect(env.is_default?).to eq false
-      expect(env.to_hash["default"]).to eq false
+      expect(env.to_hash[:default]).to eq false
+    end
+  end
+
+  describe "to_hash" do
+    it "turns keys into symbols" do
+      args = {"name" => name, "default" => false}
+      reparsed = Canals::Environment.new(args).to_hash
+      expect(reparsed.keys).to all be_an(Symbol)
     end
   end
 end


### PR DESCRIPTION
Adds an adhoc command to canals.
`adhoc` will create a temporary tunnel which is set in your session, but won't be saved in the repository, so once it is stopped, you'll need to recreate it with another adhoc command.