### PR TITLE
Add SOCKS support

### DIFF
--- a/assets/canals.sh
+++ b/assets/canals.sh
@@ -10,7 +10,7 @@ _canal_complete() {
   # Setup the base level (everything after "canal")
   if [ $COMP_CWORD -eq 1 ]; then
     COMPREPLY=( $(compgen \
-                  -W "adhoc create environment help repo restart session setup start stop update" \
+                  -W "adhoc create environment help repo restart session setup socks start stop update" \
                   -- $cur) )
     return 0
   fi

--- a/canals.gemspec
+++ b/canals.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.require_path          = "lib"
   s.license               = "MIT"
 
-  s.add_dependency        'thor', '~> 0.19.1'
-  s.add_dependency        'terminal-table', '~> 1.5'
+  s.add_dependency        'thor', '~> 0.20.3'
+  s.add_dependency        'terminal-table', '~> 1.8'
 
   s.add_development_dependency 'rspec', '~> 3.4'
 end

--- a/lib/canals/cli.rb
+++ b/lib/canals/cli.rb
@@ -137,14 +137,17 @@ module Canals
       end
 
 
-      desc "socks HOSTNAME LOCAL_PORT", "Create and run a socks connection"
+      desc "socks LOCAL_PORT", "Create and run a socks connection"
       method_option :name,         :type => :string, :desc => "The name to use for the socks tunnel, if not supplied a template will be generated"
+      method_option :env,          :type => :string, :desc => "The proxy environment to use"
+      method_option :hostname,     :type => :string, :desc => "The proxy host we will use to connect through"
       method_option :user,         :type => :string, :desc => "The user for the ssh socks host"
       method_option :bind_address, :type => :string, :desc => "The bind address to connect to"
-      def socks(hostname, local_port)
-        opts = {"adhoc" => true, "socks" => true, "hostname" => hostname, "local_port" => local_port}.merge(options)
-        opts["name"] ||= "SOCKS-adhoc-#{hostname}-#{local_port}"
+      def socks(local_port)
+        opts = {"adhoc" => true, "socks" => true, "local_port" => local_port}.merge(options)
+        opts["name"] ||= "__SOCKS__"
         opts = Canals::CanalOptions.new(opts)
+        opts.name = "SOCKS-adhoc-#{opts.hostname}-#{local_port}" if opts.name == "__SOCKS__"
         tstart(opts)
       end
 

--- a/lib/canals/cli.rb
+++ b/lib/canals/cli.rb
@@ -136,6 +136,18 @@ module Canals
         tstart(opts)
       end
 
+
+      desc "socks HOSTNAME LOCAL_PORT", "Create and run a socks connection"
+      method_option :name,         :type => :string, :desc => "The name to use for the socks tunnel, if not supplied a template will be generated"
+      method_option :user,         :type => :string, :desc => "The user for the ssh socks host"
+      method_option :bind_address, :type => :string, :desc => "The bind address to connect to"
+      def socks(hostname, local_port)
+        opts = {"adhoc" => true, "socks" => true, "hostname" => hostname, "local_port" => local_port}.merge(options)
+        opts["name"] ||= "SOCKS-adhoc-#{hostname}-#{local_port}"
+        opts = Canals::CanalOptions.new(opts)
+        tstart(opts)
+      end
+
       desc "environment SUBCOMMAND", "Environment related command (use 'canal environment help' to find out more)"
       subcommand "environment", Canals::Cli::Environment
 

--- a/lib/canals/cli.rb
+++ b/lib/canals/cli.rb
@@ -32,7 +32,7 @@ module Canals
       method_option :user,         :type => :string, :desc => "The user for the ssh proxy host"
       method_option :bind_address, :type => :string, :desc => "The bind address to connect to"
       def create(name, remote_host, remote_port, local_port=nil)
-        opts = {"name" => name, "remote_host" => remote_host, "remote_port" => remote_port, "local_port" => local_port}.merge(options)
+        opts = {name: name, remote_host: remote_host, remote_port: remote_port, local_port: local_port}.merge(options)
         opts = Canals::CanalOptions.new(opts)
         Canals.create_tunnel(opts)
         say "Tunnel #{name.inspect} created.", :green
@@ -40,13 +40,13 @@ module Canals
 
       desc 'delete NAME', "Delete an existing tunnel; if tunnel is active, stop it first"
       def delete(name)
-        tunnel = Canals.repository.get(name)
+        tunnel = Canals.repository.get(name.to_sym)
         if tunnel.nil?
           say "couldn't find tunnel #{name.inspect}. try using 'create' instead", :red
           return
         end
         tstop(name, silent: true)
-        Canals.repository.delete(name)
+        Canals.repository.delete(name.to_sym)
         say "Tunnel #{name.inspect} deleted.", :green
       end
 
@@ -59,7 +59,7 @@ module Canals
       method_option :user,         :type => :string, :desc => "The user for the ssh proxy host"
       method_option :bind_address, :type => :string, :desc => "The bind address to connect to"
       def update(name)
-        tunnel = Canals.repository.get(name)
+        tunnel = Canals.repository.get(name.to_sym)
         if tunnel.nil?
           say "couldn't find tunnel #{name.inspect}. try using 'create' instead", :red
           return

--- a/lib/canals/cli/environment.rb
+++ b/lib/canals/cli/environment.rb
@@ -3,7 +3,6 @@ require 'canals/options'
 require 'canals/environment'
 require 'thor'
 
-
 module Canals
   module Cli
     class Environment < Thor
@@ -19,8 +18,8 @@ module Canals
           host = hostname
           user = nil
         end
-        opts = {"name" => name, "hostname" => host}.merge(options)
-        opts["user"] = user if !user.nil?
+        opts = {name: name, hostname: host}.merge(options)
+        opts[:user] = user if !user.nil?
         env = Canals::Environment.new(opts)
         Canals.repository.add_environment(env)
       end

--- a/lib/canals/cli/helpers.rb
+++ b/lib/canals/cli/helpers.rb
@@ -6,11 +6,11 @@ module Canals
   module Cli
     module Helpers
 
-      def tstop(tunnel_opts, silent: false)
+      def tstop(tunnel_opts, remove_from_session: true, silent: false)
         if tunnel_opts.instance_of? String
           tunnel_opts = tunnel_options(tunnel_opts)
         end
-        Canals.stop(tunnel_opts)
+        Canals.stop(tunnel_opts, remove_from_session: remove_from_session)
         say "Tunnel #{tunnel_opts.name.inspect} stopped." unless silent
       end
 

--- a/lib/canals/cli/session.rb
+++ b/lib/canals/cli/session.rb
@@ -42,10 +42,17 @@ module Canals
         end
       end
 
-      desc "stop", "Stop the current session"
+      desc "stop", "Stop the current session (stops and removes from session)"
       def stop
         on_all_canals_in_session(:stop) do |canal|
           tstop(canal)
+        end
+      end
+
+      desc "suspend", "Suspend the current session (stops and doesn't remove from session)"
+      def suspend
+        on_all_canals_in_session(:suspend) do |canal|
+          tstop(canal, remove_from_session: false)
         end
       end
 

--- a/lib/canals/cli/setup.rb
+++ b/lib/canals/cli/setup.rb
@@ -19,7 +19,6 @@ module Canals
       desc "completion", "Setup bash completion"
       def completion
         install_completion
-        say "Bash completion script upgraded, use `source #{Canals::Tools::Completion.cmp_file}` to reload it", :red
       end
 
       desc "bind-address", "Setup a global bind address (defaults to 127.0.0.1)"
@@ -32,7 +31,7 @@ module Canals
         def setup_first_environment
           say "We'll start by setting up your first environment", :green
           say "An 'environment' is the server you connect your tunnels through. you can have many environments."
-          say "The first environment is the default one used for new connections (but you can always change this default in the future"
+          say "The first environment is the default one used for new connections (but you can always change this default in the future)"
           say ""
           return unless yes? "Wait, should we setup your first environment?", :green
           opts = {}
@@ -82,8 +81,9 @@ module Canals
         end
 
         def install_completion
-          Canals::Tools::Completion.install_completion
-          say "Shell completion installed.", :green
+          first_time = Canals::Tools::Completion.install_completion
+          say "Shell completion installed.", :green if first_time
+          say "Bash completion script #{first_time ? "installed" : "upgraded"}, use `source #{Canals::Tools::Completion.cmp_file}` to reload it", :red
         end
 
         def check(check_result, message)

--- a/lib/canals/config.rb
+++ b/lib/canals/config.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'fileutils'
 require 'forwardable'
 require 'canals/tools/yaml'
 

--- a/lib/canals/config.rb
+++ b/lib/canals/config.rb
@@ -1,6 +1,6 @@
-require 'psych'
 require 'pathname'
 require 'forwardable'
+require 'canals/tools/yaml'
 
 module Canals
   class Config
@@ -16,14 +16,12 @@ module Canals
     def load_config(config_file)
       valid_file = config_file && config_file.exist? && !config_file.size.zero?
       return {} if !valid_file
-      return Psych.load_file(config_file)
+      return Canals::Tools::YAML.load_file(config_file)
     end
 
     def save!
       FileUtils.mkdir_p(global_config_file.dirname)
-      File.open(global_config_file, 'w') do |file|
-        file.write(Psych.dump(@config))
-      end
+      Canals::Tools::YAML.dump_file(global_config_file, @config)
     end
 
     private

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -60,9 +60,9 @@ module Canals
     def tunnel_start(tunnel_opts)
       FileUtils.mkdir_p("/tmp/canals")
       if (tunnel_opts.socks)
-        cmd = "ssh -M -S #{socket_file(tunnel_opts)} -o 'ExitOnForwardFailure yes' -fnNT -D \"#{tunnel_opts.bind_address}:#{tunnel_opts.local_port}\" #{tunnel_opts.proxy}"
+        cmd = "ssh -M -S #{socket_file(tunnel_opts)} -o 'ExitOnForwardFailure=yes' -fnNT -D \"#{tunnel_opts.bind_address}:#{tunnel_opts.local_port}\" #{tunnel_opts.proxy}"
       else
-        cmd = "ssh -M -S #{socket_file(tunnel_opts)} -o 'ExitOnForwardFailure yes' -fnNT -L #{tunnel_opts.bind_address}:#{tunnel_opts.local_port}:#{tunnel_opts.remote_host}:#{tunnel_opts.remote_port} #{tunnel_opts.proxy}"
+        cmd = "ssh -M -S #{socket_file(tunnel_opts)} -o 'ExitOnForwardFailure=yes' -fnNT -L #{tunnel_opts.bind_address}:#{tunnel_opts.local_port}:#{tunnel_opts.remote_host}:#{tunnel_opts.remote_port} #{tunnel_opts.proxy}"
       end
       system(cmd)
       $?

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -24,7 +24,7 @@ module Canals
       pid.to_i
     end
 
-    def stop(tunnel_opts)
+    def stop(tunnel_opts, remove_from_session: true)
       if tunnel_opts.instance_of? String
         if (Canals.repository.has?(tunnel_opts))
           tunnel_opts = Canals.repository.get(tunnel_opts)
@@ -33,7 +33,7 @@ module Canals
         end
       end
       tunnel_close(tunnel_opts)
-      Canals.session.del(tunnel_opts.name)
+      Canals.session.del(tunnel_opts.name) if remove_from_session
     end
 
     def restart(tunnel_opts)

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'fileutils'
 
 module Canals
 

--- a/lib/canals/core.rb
+++ b/lib/canals/core.rb
@@ -59,7 +59,11 @@ module Canals
 
     def tunnel_start(tunnel_opts)
       FileUtils.mkdir_p("/tmp/canals")
-      cmd = "ssh -M -S #{socket_file(tunnel_opts)} -o 'ExitOnForwardFailure yes' -fnNT -L #{tunnel_opts.bind_address}:#{tunnel_opts.local_port}:#{tunnel_opts.remote_host}:#{tunnel_opts.remote_port} #{tunnel_opts.proxy}"
+      if (tunnel_opts.socks)
+        cmd = "ssh -M -S #{socket_file(tunnel_opts)} -o 'ExitOnForwardFailure yes' -fnNT -D \"#{tunnel_opts.bind_address}:#{tunnel_opts.local_port}\" #{tunnel_opts.proxy}"
+      else
+        cmd = "ssh -M -S #{socket_file(tunnel_opts)} -o 'ExitOnForwardFailure yes' -fnNT -L #{tunnel_opts.bind_address}:#{tunnel_opts.local_port}:#{tunnel_opts.remote_host}:#{tunnel_opts.remote_port} #{tunnel_opts.proxy}"
+      end
       system(cmd)
       $?
     end

--- a/lib/canals/environment.rb
+++ b/lib/canals/environment.rb
@@ -1,4 +1,4 @@
-require 'psych'
+require 'canals/tools/yaml'
 
 module Canals
   class CanalEnvironmentError < StandardError; end
@@ -28,7 +28,7 @@ module Canals
     end
 
     def to_yaml
-      Psych.dump(@args)
+      Canals::Tools::YAML.to_yaml(@args)
     end
 
     def to_hash

--- a/lib/canals/options.rb
+++ b/lib/canals/options.rb
@@ -77,7 +77,6 @@ module Canals
       vargs = args.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
       raise CanalOptionError.new("Missing option: \"name\" in canal creation") if vargs[:name].nil?
       if vargs[:socks]
-        raise CanalOptionError.new("Missing option: \"hostname\" in canal creation") if vargs[:hostname].nil?
         raise CanalOptionError.new("Missing option: \"local_port\" in canal creation") if vargs[:local_port].nil?
       else
         raise CanalOptionError.new("Missing option: \"remote_host\" in canal creation") if vargs[:remote_host].nil?

--- a/lib/canals/options.rb
+++ b/lib/canals/options.rb
@@ -1,4 +1,4 @@
-require 'psych'
+require 'canals/tools/yaml'
 
 module Canals
   CanalOptionError = Class.new StandardError
@@ -57,7 +57,7 @@ module Canals
     end
 
     def to_yaml
-      Psych.dump(@args)
+      Canals::Tools::YAML.to_yaml(@args)
     end
 
     def to_hash(mode=:basic)

--- a/lib/canals/options.rb
+++ b/lib/canals/options.rb
@@ -5,10 +5,10 @@ module Canals
 
   class CanalOptions
     BIND_ADDRESS = "127.0.0.1"
-    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env, :adhoc
+    attr_reader :name, :remote_host, :remote_port, :local_port, :env_name, :env, :adhoc, :socks
 
     # define setters
-    [:name, :local_port, :adhoc].each do |attribute|
+    [:name, :local_port, :adhoc, :socks].each do |attribute|
       define_method :"#{attribute}=" do |value|
         @args[attribute] = value
         self.instance_variable_set(:"@#{attribute}", value)
@@ -23,6 +23,7 @@ module Canals
       @remote_port = @args[:remote_port]
       @local_port = @args[:local_port]
       @adhoc = @args[:adhoc] || false
+      @socks = @args[:socks] || false
       @env_name = @args[:env]
       @env = Canals.repository.environment(@env_name)
     end
@@ -67,7 +68,7 @@ module Canals
     end
 
     def exploded_options
-      {bind_address: bind_address, hostname: hostname, user: user, pem: pem, proxy: proxy, adhoc: adhoc}
+      {bind_address: bind_address, hostname: hostname, user: user, pem: pem, proxy: proxy, adhoc: adhoc, socks: socks}
     end
 
     private
@@ -75,8 +76,14 @@ module Canals
     def validate?(args)
       vargs = args.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
       raise CanalOptionError.new("Missing option: \"name\" in canal creation") if vargs[:name].nil?
-      raise CanalOptionError.new("Missing option: \"remote_host\" in canal creation") if vargs[:remote_host].nil?
-      raise CanalOptionError.new("Missing option: \"remote_port\" in canal creation") if vargs[:remote_port].nil?
+      if vargs[:socks]
+        raise CanalOptionError.new("Missing option: \"hostname\" in canal creation") if vargs[:hostname].nil?
+        raise CanalOptionError.new("Missing option: \"local_port\" in canal creation") if vargs[:local_port].nil?
+      else
+        raise CanalOptionError.new("Missing option: \"remote_host\" in canal creation") if vargs[:remote_host].nil?
+        raise CanalOptionError.new("Missing option: \"remote_port\" in canal creation") if vargs[:remote_port].nil?
+      end
+
       vargs[:remote_port] = vargs[:remote_port].to_i
       if vargs[:local_port].nil?
         vargs[:local_port] = vargs[:remote_port]

--- a/lib/canals/repository.rb
+++ b/lib/canals/repository.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'fileutils'
 require 'forwardable'
 require 'canals/environment'
 require 'canals/tools/yaml'

--- a/lib/canals/repository.rb
+++ b/lib/canals/repository.rb
@@ -1,7 +1,7 @@
-require 'psych'
 require 'pathname'
 require 'forwardable'
 require 'canals/environment'
+require 'canals/tools/yaml'
 
 module Canals
   class Repository
@@ -27,9 +27,9 @@ module Canals
     end
 
     def add(options, save=true)
-      @repo[TUNNELS][options.name] = options.to_hash
+      @repo[TUNNELS][options.name.to_sym] = options.to_hash
       if options.env_name.nil? && !options.env.nil? && options.env.is_default?
-        @repo[TUNNELS][options.name][:env] = options.env.name
+        @repo[TUNNELS][options.name.to_sym][:env] = options.env.name
       end
       save! if save
     end
@@ -40,37 +40,36 @@ module Canals
     end
 
     def get(name)
+      name = name.to_sym
       return nil if !@repo[:tunnels].has_key? name
       CanalOptions.new(@repo[:tunnels][name])
     end
 
     def has?(name)
-      return @repo[:tunnels].has_key? name
+      return @repo[:tunnels].has_key? name.to_sym
     end
 
     def add_environment(environment, save=true)
       if environment.is_default?
-        @repo[ENVIRONMENTS].each { |name, env| env.delete("default") }
+        @repo[ENVIRONMENTS].each { |name, env| env.delete(:default) }
       end
       if @repo[ENVIRONMENTS].empty?
         environment.default = true
       end
-      @repo[ENVIRONMENTS][environment.name] = environment.to_hash
+      @repo[ENVIRONMENTS][environment.name.to_sym] = environment.to_hash
       save! if save
     end
 
     def save!
       FileUtils.mkdir_p(repo_file.dirname)
-      File.open(repo_file, 'w') do |file|
-        file.write(Psych.dump(@repo))
-      end
+      Canals::Tools::YAML.dump_file(repo_file, @repo)
     end
 
     def environment(name=nil)
       if name.nil?
-        args = @repo[ENVIRONMENTS].select{ |n,e| e["default"] }.values[0]
+        args = @repo[ENVIRONMENTS].select{ |n,e| e[:default] }.values[0]
       else
-        args = @repo[ENVIRONMENTS][name]
+        args = @repo[ENVIRONMENTS][name.to_sym]
       end
       Canals::Environment.new(args) if !args.nil?
     end
@@ -89,7 +88,7 @@ module Canals
     def load_repository(repository_file)
       valid_file = repository_file && repository_file.exist? && !repository_file.size.zero?
       return { ENVIRONMENTS => {}, TUNNELS => {} } if !valid_file
-      return Psych.load_file(repository_file)
+      return Canals::Tools::YAML.load_file(repository_file)
     end
 
   end

--- a/lib/canals/session.rb
+++ b/lib/canals/session.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'fileutils'
 require 'forwardable'
 require 'canals/tools/yaml'
 

--- a/lib/canals/session.rb
+++ b/lib/canals/session.rb
@@ -1,6 +1,6 @@
-require 'psych'
 require 'pathname'
 require 'forwardable'
+require 'canals/tools/yaml'
 
 module Canals
   class Session
@@ -65,9 +65,7 @@ module Canals
 
     def save!
       FileUtils.mkdir_p(session_file.dirname)
-      File.open(session_file, 'w') do |file|
-        file.write(Psych.dump(@session))
-      end
+      Canals::Tools::YAML.dump_file(session_file, @session)
     end
 
     private
@@ -80,7 +78,7 @@ module Canals
     def load_session(_session_file)
       valid_file = _session_file && _session_file.exist? && !_session_file.size.zero?
       return [] if !valid_file
-      return Psych.load_file(_session_file)
+      Canals::Tools::YAML.load_file(_session_file)
     end
 
     def basic?(sess)

--- a/lib/canals/tools/completion.rb
+++ b/lib/canals/tools/completion.rb
@@ -21,8 +21,9 @@ module Canals
         source = "source " << cmp_file
 
         rcfile = File.expand_path('.bashrc', ENV['HOME'])
-        return if File.read(rcfile).include? source
+        return false if File.read(rcfile).include? source
         File.open(rcfile, 'a') { |f| f.puts("", "# added by canals gem", "[ -f #{cmp_file} ] && #{source}") }
+        true
       end
 
       def update_completion

--- a/lib/canals/tools/completion.rb
+++ b/lib/canals/tools/completion.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'canals'
 require 'canals/tools/assets'
 

--- a/lib/canals/tools/yaml.rb
+++ b/lib/canals/tools/yaml.rb
@@ -1,0 +1,28 @@
+require 'psych'
+
+module Canals
+  module Tools
+    module YAML
+
+      def self.load(content)
+        Psych.load(content, symbolize_names: true)
+      end
+
+      def self.load_file(filename)
+        File.open(filename, 'r:bom|utf-8') { |f|
+          Psych.load(f, filename, fallback: false, symbolize_names: true)
+        }
+      end
+
+      def self.dump_file(filename, content)
+        File.open(filename, 'w') do |f|
+          f.write(self.to_yaml(content))
+        end
+      end
+
+      def self.to_yaml(content)
+        Psych.dump(content)
+      end
+    end
+  end
+end

--- a/lib/canals/version.rb
+++ b/lib/canals/version.rb
@@ -1,6 +1,6 @@
 module Canals
 
   # Canals gem current version
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 
 end

--- a/spec/canals/options_spec.rb
+++ b/spec/canals/options_spec.rb
@@ -13,6 +13,7 @@ describe Canals::CanalOptions do
   let(:user)  { "user" }
   let(:pem)  { "/tmp/file.pem" }
   let(:adhoc)  { true }
+  let(:socks)  { true }
 
   describe "name" do
     it "contains 'name'" do
@@ -92,6 +93,30 @@ describe Canals::CanalOptions do
       args = {"name" => name, "remote_host" => remote_host, "remote_port" => remote_port}
       opt = Canals::CanalOptions.new(args)
       expect(opt.adhoc).to eq false
+    end
+  end
+
+  describe "socks" do
+    it "returns 'socks' if 'socks' is availble" do
+      args = {"name" => name, "remote_host" => remote_host, "remote_port" => remote_port, "local_port" => local_port, "hostname" => hostname, "socks" => socks}
+      opt = Canals::CanalOptions.new(args)
+      expect(opt.socks).to eq socks
+    end
+
+    it "returns 'false' for 'socks' if 'socks' isn't given" do
+      args = {"name" => name, "remote_host" => remote_host, "remote_port" => remote_port, "local_port" => local_port, "hostname" => hostname}
+      opt = Canals::CanalOptions.new(args)
+      expect(opt.socks).to eq false
+    end
+
+    it "raises error when 'socks' is true and 'hostname' is not availble" do
+      args = {"name" => name, "local_port" => local_port, "socks" => socks}
+      expect{Canals::CanalOptions.new(args)}.to raise_error(Canals::CanalOptionError)
+    end
+
+    it "raises error when 'socks' is true and 'local_port' is not availble" do
+      args = {"name" => name, "hostname" => hostname, "socks" => socks}
+      expect{Canals::CanalOptions.new(args)}.to raise_error(Canals::CanalOptionError)
     end
   end
 

--- a/spec/canals/options_spec.rb
+++ b/spec/canals/options_spec.rb
@@ -1,5 +1,5 @@
 require 'canals/options'
-require 'psych'
+require 'canals/tools/yaml'
 
 describe Canals::CanalOptions do
 
@@ -210,7 +210,7 @@ describe Canals::CanalOptions do
     it "dumps remote_port as int" do
       args = {"name" => name, "remote_host" => remote_host, "remote_port" => '1234'}
       yaml = Canals::CanalOptions.new(args).to_yaml
-      reparsed = Psych.load(yaml)
+      reparsed = Canals::Tools::YAML.load(yaml)
       expect(reparsed[:remote_port]).to eq 1234
       expect(reparsed[:local_port]).to eq 1234
     end
@@ -218,7 +218,7 @@ describe Canals::CanalOptions do
     it "dumps local_port as int" do
       args = {"name" => name, "remote_host" => remote_host, "remote_port" => remote_port, "local_port" => "4321"}
       yaml = Canals::CanalOptions.new(args).to_yaml
-      reparsed = Psych.load(yaml)
+      reparsed = Canals::Tools::YAML.load(yaml)
       expect(reparsed[:local_port]).to eq 4321
     end
   end

--- a/spec/canals/options_spec.rb
+++ b/spec/canals/options_spec.rb
@@ -109,11 +109,6 @@ describe Canals::CanalOptions do
       expect(opt.socks).to eq false
     end
 
-    it "raises error when 'socks' is true and 'hostname' is not availble" do
-      args = {"name" => name, "local_port" => local_port, "socks" => socks}
-      expect{Canals::CanalOptions.new(args)}.to raise_error(Canals::CanalOptionError)
-    end
-
     it "raises error when 'socks' is true and 'local_port' is not availble" do
       args = {"name" => name, "hostname" => hostname, "socks" => socks}
       expect{Canals::CanalOptions.new(args)}.to raise_error(Canals::CanalOptionError)


### PR DESCRIPTION
 - allow to create a SOCKS connection via `canals socks <port>`
 - update gem dependencies
 - use symbols throughout the config files
 - add `suspend` to session (which closes the tunnels, but doesn't remove from session)
 - setup wizard changes.